### PR TITLE
Add OpenLayout wrapper for Home page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Home from "./pages/Home"
 import Dashboard from "./pages/Dashboard"
 import NotFound from "./pages/NotFound"
 import ProtectedRoute from "./components/ProtectedRoute"
+import OpenLayout from "./components/OpenLayout"
 
 function Logout() {
   localStorage.clear()
@@ -24,7 +25,9 @@ function App() {
         <Route
           path="/"
           element={
-            <Home />
+            <OpenLayout>
+              <Home />
+            </OpenLayout>
           }
         />
         <Route

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,22 @@
+import { Link } from "react-router-dom";
+import "../styles/Navbar.css";
+
+function Navbar() {
+    return (
+        <nav className="navbar">
+            <ul className="nav-list">
+                <li className="nav-item">
+                    <Link to="/">Home</Link>
+                </li>
+                <li className="nav-item">
+                    <Link to="/login">Login</Link>
+                </li>
+                <li className="nav-item">
+                    <Link to="/register">Register</Link>
+                </li>
+            </ul>
+        </nav>
+    );
+}
+
+export default Navbar;

--- a/frontend/src/components/OpenLayout.jsx
+++ b/frontend/src/components/OpenLayout.jsx
@@ -1,0 +1,13 @@
+import Navbar from "./Navbar";
+import "../styles/OpenLayout.css";
+
+function OpenLayout({ children }) {
+    return (
+        <div>
+            <Navbar />
+            <div className="page-body">{children}</div>
+        </div>
+    );
+}
+
+export default OpenLayout;

--- a/frontend/src/styles/Navbar.css
+++ b/frontend/src/styles/Navbar.css
@@ -1,0 +1,22 @@
+.navbar {
+    background-color: #f8f9fa;
+    padding: 10px 20px;
+    border-bottom: 1px solid #ccc;
+}
+
+.nav-list {
+    list-style: none;
+    display: flex;
+    gap: 15px;
+    margin: 0;
+    padding: 0;
+}
+
+.nav-item a {
+    text-decoration: none;
+    color: #333;
+}
+
+.nav-item a:hover {
+    text-decoration: underline;
+}

--- a/frontend/src/styles/OpenLayout.css
+++ b/frontend/src/styles/OpenLayout.css
@@ -1,0 +1,3 @@
+.page-body {
+    padding: 20px;
+}


### PR DESCRIPTION
## Summary
- create `Navbar` component with simple links
- add `OpenLayout` wrapper including navbar and body
- style the new layout components
- wrap `Home` page with the new layout in `App.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685471cb3fcc8332b3ec809b1f271464